### PR TITLE
Add Clippy Linting Result Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # lazycell
 [![Build Status](https://travis-ci.org/indiv0/lazycell.svg?branch=master)](https://travis-ci.org/indiv0/lazycell)
+[![Clippy Linting Result](http://clippy.bashy.io/github/indiv0/lazycell/master/badge.svg)](http://clippy.bashy.io/github/indiv0/lazycell/master/log)
 
 Rust library providing a lazily filled Cell.
 


### PR DESCRIPTION
A badge to see the results of the latest Clippy lint would be useful, so I am adding one to the README.md.
