### PR TITLE
Prepare Crate for Publishing to Crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,18 @@ authors = ["Alex Crichton <alex@alexcrichton.com>",
            "Nikita Pekin <contact@nikitapek.in>"]
 description = "A library providing a lazily filled Cell struct"
 repository = "https://github.com/indiv0/lazycell"
+documentation = "http://indiv0.github.io/lazycell/lazycell/"
+readme = "README.md"
 keywords = ["lazycell", "lazy", "cell", "library"]
 license = "MIT/Apache-2.0"
+include = [
+    "Cargo.toml",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+    "README.md",
+    "src/**/*.rs",
+    "src/*.rs",
+]
 
 [dependencies]
 clippy = { version = "0.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # lazycell
 [![Build Status](https://travis-ci.org/indiv0/lazycell.svg?branch=master)](https://travis-ci.org/indiv0/lazycell)
 [![Clippy Linting Result](http://clippy.bashy.io/github/indiv0/lazycell/master/badge.svg)](http://clippy.bashy.io/github/indiv0/lazycell/master/log)
+[![Crates.io](https://img.shields.io/crates/v/lazycell.svg)](https://crates.io/crates/lazycell)
+[![License: MIT/Apache-2.0](https://img.shields.io/crates/l/lazycell.svg)](#License)
 
 Rust library providing a lazily filled Cell.
 


### PR DESCRIPTION
The Cargo.toml needs to be updated before the crate is ready to package and publich to crates.io.
