### PR TITLE
Clean Up Code with rustfmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ impl<T> LazyCell<T> {
     }
 
     /// Test whether this cell has been previously filled.
-    pub fn filled(&self) -> bool { self.inner.borrow().is_some() }
+    pub fn filled(&self) -> bool {
+        self.inner.borrow().is_some()
+    }
 
     /// Borrows the contents of this lazy cell for the duration of the cell
     /// itself.
@@ -47,7 +49,7 @@ impl<T> LazyCell<T> {
     pub fn borrow(&self) -> Option<&T> {
         match *self.inner.borrow() {
             Some(ref inner) => unsafe { Some(mem::transmute(inner)) },
-            None => None
+            None => None,
         }
     }
 


### PR DESCRIPTION
The code is currently not following Rust style guidelines.

This PR runs rustfmt on the source to standardize the style.
