### PR TITLE
Implement Missing `Default` Trait for `LazyCell`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 use std::cell::RefCell;
+use std::default::Default;
 use std::mem;
 
 pub struct LazyCell<T> {
@@ -54,5 +55,12 @@ impl<T> LazyCell<T> {
     /// Consumes this `LazyCell`, returning the underlying value.
     pub fn into_inner(self) -> Option<T> {
         self.inner.into_inner()
+    }
+}
+
+impl<T> Default for LazyCell<T> {
+    #[inline]
+    fn default() -> LazyCell<T> {
+        Self::new()
     }
 }


### PR DESCRIPTION
Currently, `LazyCell` does not implement `Default`.

This PR implements the `Default` trait for `LazyCell`.
