### PR TITLE
Implement `Default` trait for `LazyCell`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
 use std::cell::RefCell;
+use std::default::Default;
 use std::mem;
 
 /// A lazily filled Cell, with frozen contents.
@@ -67,5 +68,12 @@ impl<T> LazyCell<T> {
     /// Consumes this `LazyCell`, returning the underlying value.
     pub fn into_inner(self) -> Option<T> {
         self.inner.into_inner()
+    }
+}
+
+impl<T> Default for LazyCell<T> {
+    #[inline]
+    fn default() -> LazyCell<T> {
+        Self::new()
     }
 }


### PR DESCRIPTION
Currently, `LazyCell` does not implement `Default` despite having a constructor of the form `fn new() -> Self`, which is not ideal.

This PR implements `Default` for `LazyCell`.
