### PR TITLE
Enable Travis CI Builds on `x86_64` and `i686`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ after_success:
   # actually runs from the master branch, not individual PRs)
   - travis-cargo --only stable doc-upload
 env:
+  - ARCH=x86_64
+  - ARCH=i686
   global:
     # override the default '--features unstable' used for the nightly branch
     - TRAVIS_CARGO_NIGHTLY_FEATURE="nightly-testing"


### PR DESCRIPTION
Enable Travis CI building on `x86_64` and `i686` based systems.

Closes #22.
