### PR TITLE
Add Coveralls Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
+sudo: false
 language: rust
+# necessary for `travis-cargo coveralls --no-sudo`
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev # optional: only required for the --verify flag of coveralls
 # run builds for all the trains (and more)
 rust:
   - nightly
@@ -31,6 +40,10 @@ after_success:
   # upload the documentation from the build with stable (automatically only
   # actually runs from the master branch, not individual PRs)
   - travis-cargo --only stable doc-upload
+  # measure code coverage and upload to coveralls.io (the verify argument
+  # mitigates kcov crashes due to malformed debuginfo, at the cost of some
+  # speed. <https://github.com/huonw/travis-cargo/issues/12>)
+  - travis-cargo coveralls --no-sudo --verify
 env:
   global:
     # override the default '--features unstable' used for the nightly branch

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
             <a href="https://indiv0.github.io/lazycell/lazycell" title="API Docs"><img src="https://img.shields.io/badge/API-docs-blue.svg" alt="api-docs-badge"></img></a>
             <a href="https://crates.io/crates/lazycell" title="Crates.io"><img src="https://img.shields.io/crates/v/lazycell.svg" alt="crates-io"></img></a>
             <a href="#License" title="License: MIT/Apache-2.0"><img src="https://img.shields.io/crates/l/lazycell.svg" alt="license-badge"></img></a>
+            <a href="https://coveralls.io/github/indiv0/lazycell?branch=master" title="Coverage Status"><img src="https://coveralls.io/repos/github/indiv0/lazycell/badge.svg?branch=master" alt="coveralls-badge"></img></a>
             <a href="http://clippy.bashy.io/github/indiv0/lazycell/master/log" title="Clippy Linting Result"><img src="http://clippy.bashy.io/github/indiv0/lazycell/master/badge.svg" alt="clippy-lint-badge"></img></a>
         </td>
     </tr>


### PR DESCRIPTION
Add Coveralls coverage uploading support via travis-cargo.
Add Coveralls badge to `README.md`.

Closes #17.
