### PR TITLE
Modify appveyor to only build master and auto

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 branches:
-  except:
-    - gh-pages
+  only:
+    - auto
+    - master
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
Modify `appveyor.yml` to configure Appveyor to only build master and auto
branches.
