### PR TITLE
Add `CONTRIBUTING.md`

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -2,3 +2,9 @@
 repository = "https://github.com/indiv0/lazycell"
 outfile = "CHANGELOG.md"
 from-latest-tag = true
+
+[sections]
+Performance = ["perf"]
+Improvements = ["impr", "im", "imp"]
+Documentation = ["docs"]
+Examples = ["examples"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# How to Contribute
+
+Contributions are always welcome!
+Please use the following guidelines when contributing to `lazycell`:
+
+1. Fork `lazycell`
+2. Clone your fork (`git clone https://github.com/$YOUR_USERNAME/lazycell && cd lazycell`)
+3. Create a new branch (`git checkout -b new-branch`)
+4. Make your changes
+5. Commit your changes (`git commit -am "your message"`)
+ * This project uses the
+ [conventional changelog format][conventional-changelog-format], so that we can
+ easily update the `CHANGELOG.md` using [clog][clog-cli].
+ * In addition to the conventions defined above, we also use `imp`, `wip`,
+   and `examples`.
+ * Format your commit subject line using the following format:
+   `TYPE(COMPONENT): MESSAGE` where `TYPE` is one of the following:
+    - `feat` - A new feature
+    - `imp` - An improvement to an existing feature
+    - `perf` - A performance improvement
+    - `docs` - Changes to documentation only
+    - `tests` - Changes to the testing framework or tests only
+    - `fix` - A bug fix
+    - `refactor` - Code functionality doesn't change, but underlying structure
+      may
+    - `style` - Stylistic changes only, no functionality changes
+    - `wip` - A work in progress commit (Should typically be `git rebase`'ed
+      away)
+    - `chore` - Catch all or things that have to do with the build system, etc.
+    - `examples` - Changes to an existing example, or a new example
+ * The `COMPONENT` is optional, and may be a single file, directory, or logical
+   component.
+   Can be omitted if commit applies globally
+6. Run the tests (`cargo test`)
+7. `git rebase` into concise commits and remove `--fixup`s
+   (`git rebase -i HEAD~NUM` where `NUM` is number of commits back)
+8. Push your changes back to your fork (`git push origin $your-branch`)
+9. Create a pull request! (You can also create the pull request first, and
+   we'll merge when ready.
+   This a good way to discuss proposed changes.)
+
+[clog-cli]: https://github.com/clog-tool/clog-cli "clog-tool/clog-cli"
+[conventional-changelog-format]: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit "Angular Git Commit Guidelines"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+The following is a list of contributors to the [lazycell][lazycell] project, in
+alphabetical order.
+
+* [Nikita Pekin](https://github.com/indiv0)
+
+[lazycell]: https://github.com/indiv0/lazycell

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,5 @@
 Original work Copyright (c) 2014 The Rust Project Developers
-Modified work Copyright (c) 2016 Nikita Pekin
+Modified work Copyright (c) 2016 Nikita Pekin and lazycell contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@
 
 Rust library providing a lazily filled Cell.
 
+# Table of Contents
+
+* [Usage](#usage)
+* [Contributing](#contributing)
+* [Credits](#credits)
+* [License](#license)
+
 ## Usage
 
 Add the following to your `Cargo.toml`:
@@ -39,10 +46,21 @@ extern crate lazycell;
 
 See the [API docs][api-docs] for information on using the crate in your library.
 
+## Contributing
+
+Contributions are always welcome!
+If you have an idea for something to add (code, documentation, tests, examples,
+etc.) feel free to give it a shot.
+
+Please read [CONTRIBUTING.md][contributing] before you start contributing.
+
 ## Credits
 
 The LazyCell library is based originally on work by The Rust Project Developers
 for the project [crates.io][crates-io-repo].
+
+The list of contributors to this project can be found at
+[CONTRIBUTORS.md][contributors].
 
 ## License
 
@@ -52,6 +70,8 @@ License (Version 2.0).
 See [LICENSE-APACHE][license-apache], and [LICENSE-MIT][license-mit] for details.
 
 [api-docs]: https://indiv0.github.io/lazycell/lazycell
+[contributing]: https://github.com/indiv0/lazycell/blob/master/CONTRIBUTING.md "Contribution Guide"
+[contributors]: https://github.com/indiv0/lazycell/blob/master/CONTRIBUTORS.md "List of Contributors"
 [crates-io-repo]: https://github.com/rust-lang/crates.io "rust-lang/crates.io: Source code for crates.io"
 [license-apache]: https://github.com/indiv0/lazycell/blob/master/LICENSE-APACHE "Apache-2.0 License"
 [license-mit]: https://github.com/indiv0/lazycell/blob/master/LICENSE-MIT "MIT License"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Original work Copyright (c) 2014-2015 The Rust Project Developers
-// Modified work Copyright (c) 2016 Nikita Pekin
+// Modified work Copyright (c) 2016 Nikita Pekin and the lazycell contributors
 // See the README.md file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or


### PR DESCRIPTION
Add a `CONTRIBUTING.md` file with instructions on contribution.
Update `.clog.toml`.
Add `CONTRIBUTORS.md`.
Add information about `CONTRIBUTORS.md` and `CONTRIBUTING.md` to `README.md`.
Fix copyright headers.

Closes #19.
