### PR TITLE
Enable fast_finish for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,4 @@ notifications:
 matrix:
   allow_failures:
     - rust: nightly
+  fast_finish: true


### PR DESCRIPTION
Enable `fast_finish` for Travis CI builds.
