### PR TITLE
Remove Clippy linting badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
             <a href="https://crates.io/crates/lazycell" title="Crates.io"><img src="https://img.shields.io/crates/v/lazycell.svg" alt="crates-io"></img></a>
             <a href="#license" title="License: MIT/Apache-2.0"><img src="https://img.shields.io/crates/l/lazycell.svg" alt="license-badge"></img></a>
             <a href="https://coveralls.io/github/indiv0/lazycell?branch=master" title="Coverage Status"><img src="https://coveralls.io/repos/github/indiv0/lazycell/badge.svg?branch=master" alt="coveralls-badge"></img></a>
-            <a href="http://clippy.bashy.io/github/indiv0/lazycell/master/log" title="Clippy Linting Result"><img src="http://clippy.bashy.io/github/indiv0/lazycell/master/badge.svg" alt="clippy-lint-badge"></img></a>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
Remove Clippy service linting badge because the clippy-service currently
incorrectly returns a failing result, despite the lack of clippy issues.

Closes #45.
