### PR TITLE
Return Err(value) on full cell

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,7 +9,7 @@ fn test_lazycell() {
     assert_eq!(lazycell.borrow(), None);
     assert!(!lazycell.filled());
 
-    lazycell.fill(1);
+    lazycell.fill(1).unwrap();
 
     assert!(lazycell.filled());
     assert_eq!(lazycell.borrow(), Some(&1));
@@ -17,10 +17,9 @@ fn test_lazycell() {
 }
 
 #[test]
-#[should_panic(expected = "lazy cell is already filled")]
-fn test_already_filled_panic() {
+fn test_already_filled_error() {
     let lazycell: LazyCell<usize> = LazyCell::new();
 
-    lazycell.fill(1);
-    lazycell.fill(1);
+    lazycell.fill(1).unwrap();
+    assert_eq!(lazycell.fill(1), Err(1));
 }


### PR DESCRIPTION
Modify the `fill()` method of the `LazyCell` struct to return
`Err(value)` when attempting to fill an already filled `LazyCell`. This
is a replacement for the previous behaviour, which would return a panic
instead. The new behaviour is preferred because it allows downstream
crates to handle the error case better.

Modify tests to accomodate changes in the error behaviour of the
`fill()` method of the `LazyCell` struct.

BREAKING CHANGE: the `fill()` method of the `LazyCell` struct now
returns a `Result<(), T>`, which must be handled. The previous behaviour
was to simply panic.
