### PR TITLE
Add borrow_with to LazyCell

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,5 +3,6 @@ alphabetical order.
 
 * [Carl Lerche](https://github.com/carllerche)
 * [Nikita Pekin](https://github.com/indiv0)
+* [J/A](https://github.com/archer884)
 
 [lazycell]: https://github.com/indiv0/lazycell


### PR DESCRIPTION
Pursuant to some commentary from https://www.reddit.com/r/rust/comments/5gv3k9/lazy_fields, this adds `.borrow_with()` to `LazyCell` only. I tinkered with adding it to the atomic version, but it seemed to me the api would not be as clean there and, as a result, not nearly as useful.