### PR TITLE
Increment minimum rustc version to 1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rust:
   - stable
   # and the first stable one (this should be bumped as the minimum Rust version
   # required changes)
-  - 1.9.0
+  - 1.13.0
 os:
   - linux
 cache: cargo


### PR DESCRIPTION
Increment the minimum rustc version to support the carrier trait ("?").