### PR TITLE
style: remove unnecessary mut and unsafe keywords

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,5 +7,6 @@ alphabetical order.
 * [J/A](https://github.com/archer884)
 * [Jack O'Connor](https://github.com/oconnor663)
 * [Nikita Pekin](https://github.com/indiv0)
+* [Ossi Herrala](https://github.com/oherrala)
 
 [lazycell]: https://github.com/indiv0/lazycell

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,11 @@ impl<T> LazyCell<T> {
 
     /// Consumes this `LazyCell`, returning the underlying value.
     pub fn into_inner(self) -> Option<T> {
-        self.inner.into_inner()
+        // Rust 1.25 changed UnsafeCell::into_inner() from unsafe to safe
+        // function. This unsafe can be removed when supporting Rust older than
+        // 1.25 is not needed.
+        #[allow(unused_unsafe)]
+        unsafe { self.inner.into_inner() }
     }
 }
 
@@ -206,7 +210,11 @@ impl<T> AtomicLazyCell<T> {
 
     /// Consumes this `LazyCell`, returning the underlying value.
     pub fn into_inner(self) -> Option<T> {
-        self.inner.into_inner()
+        // Rust 1.25 changed UnsafeCell::into_inner() from unsafe to safe
+        // function. This unsafe can be removed when supporting Rust older than
+        // 1.25 is not needed.
+        #[allow(unused_unsafe)]
+        unsafe { self.inner.into_inner() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Original work Copyright (c) 2014 The Rust Project Developers
-// Modified work Copyright (c) 2016-2017 Nikita Pekin and the lazycell contributors
+// Modified work Copyright (c) 2016-2018 Nikita Pekin and the lazycell contributors
 // See the README.md file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -63,7 +63,7 @@ impl<T> LazyCell<T> {
     ///
     /// This function will return `Err(value)` is the cell is already full.
     pub fn fill(&self, value: T) -> Result<(), T> {
-        let mut slot = unsafe { &mut *self.inner.get() };
+        let slot = unsafe { &mut *self.inner.get() };
         if slot.is_some() {
             return Err(value);
         }
@@ -135,7 +135,7 @@ impl<T> LazyCell<T> {
 
     /// Consumes this `LazyCell`, returning the underlying value.
     pub fn into_inner(self) -> Option<T> {
-        unsafe { self.inner.into_inner() }
+        self.inner.into_inner()
     }
 }
 
@@ -206,7 +206,7 @@ impl<T> AtomicLazyCell<T> {
 
     /// Consumes this `LazyCell`, returning the underlying value.
     pub fn into_inner(self) -> Option<T> {
-        unsafe { self.inner.into_inner() }
+        self.inner.into_inner()
     }
 }
 


### PR DESCRIPTION
Compiler nagged about these. Remove it to please the compiler.