### PR TITLE
Add #![no_std]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@ alphabetical order.
 * [Aaron Trent](https://github.com/novacrazy)
 * [Aleksey Kladov](https://github.com/matklad)
 * [Carl Lerche](https://github.com/carllerche)
+* [est31](https://github.com/est31)
 * [J/A](https://github.com/archer884)
 * [Jack O'Connor](https://github.com/oconnor663)
 * [Nikita Pekin](https://github.com/indiv0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg_attr(not(test), no_std)]
+
 #![deny(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
@@ -43,6 +45,10 @@
 //!
 //! `AtomicLazyCell` is a variant that uses an atomic variable to manage
 //! coordination in a thread-safe fashion.
+
+#[cfg(not(test))]
+#[macro_use]
+extern crate core as std;
 
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
This crate uses nothing from the std crate that's not already
present in libcore. Therefore, add a #![no_std] tag.