### PR TITLE
Cut the 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="v1.0.0"></a>
+## v1.0.0 (2018-06-06)
+
+
+#### Features
+
+*   Add #![no_std] ([e59f6b55](https://github.com/indiv0/lazycell/commit/e59f6b5531e310d3df26b0eb40b1431937f38096))
+
+
+
 <a name="0.6.0"></a>
 ## 0.6.0 (2017-11-25)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazycell"
-version = "0.6.0"
+version = "1.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>",
            "Nikita Pekin <contact@nikitapek.in>"]
 description = "A library providing a lazily filled Cell struct"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lazycell = "0.6"
+lazycell = "1.0"
 ```
 
 And in your `lib.rs` or `main.rs`:


### PR DESCRIPTION
Update CHANGELOG.
Update README.
Cut the 0.6.0 release.