### PR TITLE
Add NONE constant for an empty AtomicLazyCell

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,12 +172,15 @@ pub struct AtomicLazyCell<T> {
 }
 
 impl<T> AtomicLazyCell<T> {
+    /// An empty cell.
+    pub const NONE: Self = Self {
+        inner: UnsafeCell::new(None),
+        state: AtomicUsize::new(NONE),
+    };
+
     /// Creates a new, empty, `AtomicLazyCell`.
     pub fn new() -> AtomicLazyCell<T> {
-        AtomicLazyCell {
-            inner: UnsafeCell::new(None),
-            state: AtomicUsize::new(NONE),
-        }
+        Self::NONE
     }
 
     /// Put a value into this cell.


### PR DESCRIPTION
Add an associated constant for an empty `AtomicLazyCell`. This is useful in statics and in other places requiring const expressions.

Maybe when `const fn` becomes stable, we could make `new()` also be `const`. For now this is a relatively elegant workaround.