### PR TITLE
Implement Clone for LazyCell and AtomicLazyCell

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,5 +12,6 @@ alphabetical order.
 * [Nikita Pekin](https://github.com/indiv0)
 * [Ossi Herrala](https://github.com/oherrala)
 * [Stephen M. Coakley](https://github.com/sagebind)
+* [David Halperin](https://github.com/davidhalperin)
 
 [lazycell]: https://github.com/indiv0/lazycell

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,5 @@
 Original work Copyright (c) 2014 The Rust Project Developers
-Modified work Copyright (c) 2016-2017 Nikita Pekin and lazycell contributors
+Modified work Copyright (c) 2016-2018 Nikita Pekin and lazycell contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
I ran into a paper cut trying to add a LazyCell into a pre-existing struct that derives Clone, requiring changing that to a manual implementation since LazyCell currently doesn't.