### PR TITLE
Fix unsound aliasing in `LazyCell::fill`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,11 @@ impl<T> LazyCell<T> {
     ///
     /// This function will return `Err(value)` if the cell is already full.
     pub fn fill(&self, value: T) -> Result<(), T> {
-        let slot = unsafe { &mut *self.inner.get() };
+        let slot = unsafe { &*self.inner.get() };
         if slot.is_some() {
             return Err(value);
         }
+        let slot = unsafe { &mut *self.inner.get() };
         *slot = Some(value);
 
         Ok(())


### PR DESCRIPTION
Fix unsound aliasing of the inner `Option<T>`. Per the discussion in
https://github.com/matklad/once_cell/pull/33, it is possible to obtain a
unique reference to the inner `Option<T>` despite it being potentially
aliased by a previous `.borrow()`. Kudos to @danielhenrymantilla for
spotting this issue in `matklad/once_cell` and to @matklad for pointing out that
it also applies to `LazyCell::fill`.

Closes #98.