### PR TITLE
Fixed implementation of `trait Default`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,5 +14,6 @@ alphabetical order.
 * [Nikita Pekin](https://github.com/indiv0)
 * [Ossi Herrala](https://github.com/oherrala)
 * [Stephen M. Coakley](https://github.com/sagebind)
+* [Vincent Esche](https://github.com/regexident)
 
 [lazycell]: https://github.com/indiv0/lazycell

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,4 +647,17 @@ mod tests {
         assert_eq!(clone2.borrow(), Some(&4));
         assert_eq!(cell.borrow(), Some(&2));
     }
+
+    #[test]
+    fn default() {
+        #[derive(Default)]
+        struct Defaultable;
+        struct NonDefaultable;
+
+        let _: LazyCell<Defaultable> = LazyCell::default();
+        let _: LazyCell<NonDefaultable> = LazyCell::default();
+
+        let _: AtomicLazyCell<Defaultable> = AtomicLazyCell::default();
+        let _: AtomicLazyCell<NonDefaultable> = AtomicLazyCell::default();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// A `LazyCell` is completely frozen once filled, **unless** you have `&mut`
 /// access to it, in which case `LazyCell::borrow_mut` may be used to mutate the
 /// contents.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LazyCell<T> {
     inner: UnsafeCell<Option<T>>,
 }
@@ -216,6 +216,12 @@ impl<T: Copy> LazyCell<T> {
     }
 }
 
+impl<T> Default for LazyCell<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl <T: Clone> Clone for LazyCell<T> {
     /// Create a clone of this `LazyCell`
     ///
@@ -233,7 +239,7 @@ const LOCK: usize = 1;
 const SOME: usize = 2;
 
 /// A lazily filled and thread-safe `Cell`, with frozen contents.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AtomicLazyCell<T> {
     inner: UnsafeCell<Option<T>>,
     state: AtomicUsize,
@@ -323,6 +329,12 @@ impl<T: Copy> AtomicLazyCell<T> {
             SOME => unsafe { *self.inner.get() },
             _ => None,
         }
+    }
+}
+
+impl<T> Default for AtomicLazyCell<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
As can be seen by looking at [the docs](https://docs.rs/lazycell/1.2.1/lazycell/struct.LazyCell.html#impl-Default) the use of `#[derive(Default)]` generates the following implementation signature:

```rust
impl<T: Default> Default for LazyCell<T>
```

Notice the trait bound in `impl<T: Default>`, which needlessly constrains `T` to `T: Default`, even though `T::default()` is never actually called.

Replacing the derived impl with a manually implemented one fixes the issue:

```rust
impl<T> Default for LazyCell<T> {
    fn default() -> Self {
        Self::new()
    }
}
```

(Check out the first commit to confirm the issue, which gets fixed by the second commit.)

The regression was introduced with https://github.com/indiv0/lazycell/pull/31.